### PR TITLE
Add deployment environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # LoRATrainingOrchestrationSystem
+
 We will build an automated LoRA training platform with ephemeral container workers. A central orchestrator manages jobs, SQL tracks state, and storage holds models, datasets, and outputs. A web UI enables dataset upload, model selection (SD1.5/SDXL), and job submission. All training steps run fully automated.
+
+## Development environment
+
+Use `deploy_env.sh` to perform a preflight check and install required system and Python dependencies. After the check, you can launch core infrastructure services (PostgreSQL, RabbitMQ, MinIO) with Docker Compose:
+
+```bash
+./deploy_env.sh
+# once dependencies are installed
+docker-compose up -d
+```
+
+This brings up the storage and messaging services needed for development.

--- a/deploy_env.sh
+++ b/deploy_env.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preflight check for system binaries
+REQUIRED_CMDS=(docker docker-compose kubectl helm psql rabbitmqctl mc)
+declare -A APT_PACKAGES=(
+  [docker]=docker.io
+  [docker-compose]=docker-compose
+  [kubectl]=kubectl
+  [helm]=helm
+  [psql]=postgresql-client
+  [rabbitmqctl]=rabbitmq-server
+  [mc]=minio-client
+)
+
+missing=()
+
+echo "Running system dependency check..."
+for cmd in "${REQUIRED_CMDS[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo " - $cmd: found ($(command -v "$cmd"))"
+    else
+        echo " - $cmd: MISSING"
+        missing+=("$cmd")
+    fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "Missing dependencies: ${missing[*]}"
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "Attempting to install via apt-get..."
+        apt-get update
+        apt_pkgs=()
+        for cmd in "${missing[@]}"; do
+            pkg=${APT_PACKAGES[$cmd]:-}
+            if [ -n "$pkg" ]; then
+                apt_pkgs+=("$pkg")
+            else
+                echo "  no apt package mapping for $cmd"
+            fi
+        done
+        if [ ${#apt_pkgs[@]} -gt 0 ]; then
+            apt-get install -y "${apt_pkgs[@]}" || true
+        else
+            echo "No apt packages to install."
+        fi
+    else
+        echo "apt-get not available. Install manually: ${missing[*]}"
+    fi
+else
+    echo "All system dependencies satisfied."
+fi
+
+# Python packages
+PY_PACKAGES=(fastapi uvicorn psycopg2 pika minio kubernetes)
+missing_py=()
+
+echo "Running Python package check..."
+for pkg in "${PY_PACKAGES[@]}"; do
+    if python3 -c "import $pkg" >/dev/null 2>&1; then
+        echo " - $pkg: installed"
+    else
+        echo " - $pkg: MISSING"
+        missing_py+=("$pkg")
+    fi
+done
+
+if [ ${#missing_py[@]} -gt 0 ]; then
+    echo "Installing missing Python packages..."
+    python3 -m pip install -U "${missing_py[@]}"
+else
+    echo "All Python packages satisfied."
+fi
+
+echo "Environment setup complete."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: orchestrator
+      POSTGRES_PASSWORD: orchestrator
+      POSTGRES_DB: orchestrator
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  rabbitmq:
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+  minio:
+    image: minio/minio
+    command: server /data --console-address :9001
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+
+volumes:
+  postgres_data:
+  minio_data:


### PR DESCRIPTION
## Summary
- add `deploy_env.sh` script for system and Python preflight checks with automatic installation
- provide Docker Compose file for PostgreSQL, RabbitMQ, and MinIO services
- update README with setup instructions

## Testing
- `./deploy_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bfecb0264c8333ada4b66869dc534a