### PR TITLE
Implement Kubernetes worker orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # LoRATrainingOrchestrationSystem
 We will build an automated LoRA training platform with ephemeral container workers. A central orchestrator manages jobs, SQL tracks state, and storage holds models, datasets, and outputs. A web UI enables dataset upload, model selection (SD1.5/SDXL), and job submission. All training steps run fully automated.
+
+## Orchestrator
+
+`orchestrator` contains a `KubernetesOrchestrator` class that spawns worker jobs on a Kubernetes cluster and deletes them after completion. Example usage:
+
+```python
+from orchestrator import KubernetesOrchestrator, WorkerSpec
+
+orch = KubernetesOrchestrator()
+spec = WorkerSpec(name="demo", image="alpine:latest", command=["echo", "hello"])
+orch.run_worker(spec)
+```
+
+This ensures each worker is created, monitored until it finishes, and then cleaned up.

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,5 @@
+"""Orchestrator package for managing worker nodes."""
+
+from .k8s_orchestrator import KubernetesOrchestrator, WorkerSpec
+
+__all__ = ["KubernetesOrchestrator", "WorkerSpec"]

--- a/orchestrator/k8s_orchestrator.py
+++ b/orchestrator/k8s_orchestrator.py
@@ -1,0 +1,90 @@
+"""Kubernetes-based orchestrator for spawning and cleaning up workers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from kubernetes import client, config
+import time
+
+
+@dataclass
+class WorkerSpec:
+    """Configuration for a worker Job."""
+
+    name: str
+    image: str
+    command: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+
+
+class KubernetesOrchestrator:
+    """Controls lifecycle of training workers on Kubernetes."""
+
+    def __init__(self, namespace: str = "lora-workers", batch_api: Optional[client.BatchV1Api] = None):
+        # Allow dependency injection for testing
+        if batch_api is None:
+            try:
+                config.load_incluster_config()
+            except Exception:
+                # Fall back to local config; tests may not have any config
+                try:
+                    config.load_kube_config()
+                except Exception:
+                    pass
+            batch_api = client.BatchV1Api()
+        self.batch_api = batch_api
+        self.namespace = namespace
+
+    # -------------------- core lifecycle methods --------------------
+    def spawn_worker(self, spec: WorkerSpec) -> client.V1Job:
+        """Create a Kubernetes Job for the worker."""
+        env_vars = [client.V1EnvVar(name=k, value=v) for k, v in (spec.env or {}).items()]
+        container = client.V1Container(
+            name="worker",
+            image=spec.image,
+            command=spec.command,
+            env=env_vars,
+        )
+        template = client.V1PodTemplateSpec(
+            metadata=client.V1ObjectMeta(labels={"job": spec.name}),
+            spec=client.V1PodSpec(restart_policy="Never", containers=[container]),
+        )
+        job_spec = client.V1JobSpec(template=template, backoff_limit=0)
+        job = client.V1Job(
+            api_version="batch/v1",
+            kind="Job",
+            metadata=client.V1ObjectMeta(name=spec.name),
+            spec=job_spec,
+        )
+        return self.batch_api.create_namespaced_job(self.namespace, job)
+
+    def wait_for_completion(self, name: str, timeout: int = 3600) -> None:
+        """Block until the job succeeds or fails."""
+        start = time.time()
+        while True:
+            job = self.batch_api.read_namespaced_job(name, self.namespace)
+            status = job.status
+            if status.succeeded:
+                return
+            if status.failed:
+                raise RuntimeError(f"Worker {name} failed")
+            if time.time() - start > timeout:
+                raise TimeoutError(f"Timed out waiting for job {name}")
+            time.sleep(5)
+
+    def cleanup_worker(self, name: str) -> None:
+        """Delete the worker Job and its pods."""
+        self.batch_api.delete_namespaced_job(
+            name=name,
+            namespace=self.namespace,
+            propagation_policy="Background",
+        )
+
+    def run_worker(self, spec: WorkerSpec, timeout: int = 3600) -> None:
+        """Spawn, wait for completion, and clean up the worker."""
+        self.spawn_worker(spec)
+        try:
+            self.wait_for_completion(spec.name, timeout=timeout)
+        finally:
+            self.cleanup_worker(spec.name)

--- a/tests/test_k8s_orchestrator.py
+++ b/tests/test_k8s_orchestrator.py
@@ -1,0 +1,24 @@
+import types
+from unittest import mock
+
+from orchestrator import KubernetesOrchestrator, WorkerSpec
+
+
+def test_run_worker_lifecycle():
+    # Prepare mock BatchV1Api
+    batch_api = mock.Mock()
+
+    # read_namespaced_job will be called and should report success once
+    job_status = types.SimpleNamespace(succeeded=1, failed=0)
+    job = types.SimpleNamespace(status=job_status)
+    batch_api.read_namespaced_job.return_value = job
+
+    orchestrator = KubernetesOrchestrator(batch_api=batch_api)
+
+    spec = WorkerSpec(name="test-job", image="alpine:latest", command=["echo", "hi"])
+    orchestrator.run_worker(spec, timeout=1)
+
+    # ensure lifecycle methods were called
+    batch_api.create_namespaced_job.assert_called_once()
+    batch_api.read_namespaced_job.assert_called()
+    batch_api.delete_namespaced_job.assert_called_once()


### PR DESCRIPTION
## Summary
- add Kubernetes-based orchestrator for spawning and tearing down workers
- document orchestrator usage
- test worker lifecycle with mocked Kubernetes API

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff3d9cac08333a01558d157c3e1f8